### PR TITLE
feat: introduce unit tests and CI/CD integration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,15 @@ jobs:
         run: |
           mkdir build
           VERSION=${GITHUB_REF#refs/tags/v}
-          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVERSION_OVERRIDE=$VERSION
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DVERSION_OVERRIDE=$VERSION -DENABLE_TESTS=ON
 
       - name: Build
         run: |
           cmake --build build --config Release
+
+      - name: Run Tests
+        run: |
+          ctest --test-dir build --output-on-failure
 
       - name: Packaging
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,16 +49,19 @@ Create a dedicated branch for your work using the following naming convention:
 ### 3. Implementation
 Develop the software to implement the feature or fix the issue. Ensure your code follows the existing style and architecture.
 
-> [!NOTE]
-> Testing approach is currently omitted from this guide and will be addressed in a future update.
+### 4. Testing
+The project uses Google Test (GTest) for unit testing. Tests are located in the `tests/` directory.
+- **Local Testing**: Run tests using `cmake -DENABLE_TESTS=ON` followed by `ctest`.
+- **CI/CD**: Tests are automatically executed on every push to a release tag across Linux and macOS environments.
+- **Testability**: Core logic is encapsulated in the `pdf2cbz_core` static library to facilitate testing without the `main` entry point.
 
-### 4. Pull Request
+### 5. Pull Request
 Push your branch and create a Pull Request (PR) on GitHub. Your PR should include:
 - **TLDR**: A 10-second summary of what this PR does.
 - **Description**: A detailed explanation of the changes made.
 - **Flaws/Awareness**: Highlight any known limitations, specific complexities, or portions requiring extra attention during review.
 
-### 5. Review & Merge
+### 6. Review & Merge
 After the PR is reviewed and validated by a maintainer, it can be merged into the `main` branch.
 
 ### 6. Release & Versioning

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,23 +14,49 @@ configure_file(
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(ENABLE_TESTS "Enable unit tests" OFF)
+
+if(ENABLE_TESTS)
+    cmake_policy(SET CMP0135 NEW)
+    include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      URL https://github.com/google/googletest/archive/refs/tags/v1.14.0.tar.gz
+    )
+    # For Windows: Prevent overriding the parent project's compiler/linker settings
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
+endif()
+
 # Find PkgConfig
 find_package(PkgConfig REQUIRED)
 
 # Check for Poppler
-pkg_check_modules(POPPLER REQUIRED poppler-cpp)
+pkg_check_modules(POPPLER REQUIRED IMPORTED_TARGET poppler-cpp)
 
 message(STATUS "Poppler include: ${POPPLER_INCLUDE_DIRS}")
 message(STATUS "Poppler libs: ${POPPLER_LIBRARIES}")
 message(STATUS "Poppler lib dirs: ${POPPLER_LIBRARY_DIRS}")
 
-include_directories(${POPPLER_INCLUDE_DIRS} src/vendor "${CMAKE_CURRENT_BINARY_DIR}/generated")
-link_directories(${POPPLER_LIBRARY_DIRS})
-
-add_executable(pdf2cbz
-    src/main.cpp
+# Create a library for the core logic
+add_library(pdf2cbz_core STATIC
     src/converter.cpp
     src/vendor/miniz.c
 )
+target_include_directories(pdf2cbz_core PUBLIC src src/vendor "${CMAKE_CURRENT_BINARY_DIR}/generated")
+target_link_libraries(pdf2cbz_core PUBLIC PkgConfig::POPPLER)
 
-target_link_libraries(pdf2cbz PRIVATE ${POPPLER_LIBRARIES})
+add_executable(pdf2cbz src/main.cpp)
+target_link_libraries(pdf2cbz PRIVATE pdf2cbz_core)
+
+if(ENABLE_TESTS)
+    enable_testing()
+
+    add_executable(pdf2cbz_tests
+        tests/utils_test.cpp
+        tests/converter_test.cpp
+    )
+    target_link_libraries(pdf2cbz_tests PRIVATE pdf2cbz_core gtest_main)
+
+    add_test(NAME pdf2cbz_tests COMMAND pdf2cbz_tests)
+endif()

--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ cmake --build build
 
 The executable `pdf2cbz` will be located in the `build/` directory.
 
+#### 3. Run Tests (Optional)
+
+To compile and run unit tests:
+
+```bash
+cmake -S . -B build -DENABLE_TESTS=ON
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
 ## Usage
 
 ```bash

--- a/src/converter.hpp
+++ b/src/converter.hpp
@@ -25,6 +25,9 @@ public:
   Converter(const std::string &inputPath, const std::string &outputPath);
   bool process(int threads = 0);
 
+protected:
+  int calculateNumThreads(int requestedThreads);
+
 private:
   std::string m_inputPath;
   std::string m_outputPath;

--- a/tests/converter_test.cpp
+++ b/tests/converter_test.cpp
@@ -1,0 +1,28 @@
+#include "converter.hpp"
+#include <gtest/gtest.h>
+#include <thread>
+
+class TestConverter : public Converter {
+public:
+  using Converter::calculateNumThreads;
+  using Converter::Converter;
+};
+
+TEST(ConverterTest, CalculateNumThreads) {
+  TestConverter conv("input.pdf", "output.cbz");
+
+  // Test explicit thread counts
+  EXPECT_EQ(conv.calculateNumThreads(1), 1);
+  EXPECT_EQ(conv.calculateNumThreads(4), 4);
+  EXPECT_EQ(conv.calculateNumThreads(32), 32);
+
+  // Test clamping
+  EXPECT_EQ(conv.calculateNumThreads(64), 32);
+
+  // Test auto-detection
+  int autoThreads = conv.calculateNumThreads(0);
+  EXPECT_GT(autoThreads, 0);
+  EXPECT_LE(autoThreads, 32);
+
+  EXPECT_EQ(conv.calculateNumThreads(-1), autoThreads);
+}

--- a/tests/utils_test.cpp
+++ b/tests/utils_test.cpp
@@ -1,0 +1,27 @@
+#include "utils.hpp"
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sstream>
+
+TEST(ProgressBarTest, Update) {
+  ProgressBar bar;
+
+  // We can't easily test the visual output without mocking std::cout,
+  // but we can at least ensure it doesn't crash and handles edge cases.
+
+  // Capturing stdout to avoid cluttering test output
+  std::stringstream buffer;
+  std::streambuf *old = std::cout.rdbuf(buffer.rdbuf());
+
+  bar.update(0, 100);
+  bar.update(50, 100);
+  bar.update(100, 100);
+
+  std::cout.rdbuf(old);
+
+  std::string output = buffer.str();
+  EXPECT_FALSE(output.empty());
+  EXPECT_TRUE(output.find("0 %") != std::string::npos);
+  EXPECT_TRUE(output.find("50 %") != std::string::npos);
+  EXPECT_TRUE(output.find("100 %") != std::string::npos);
+}


### PR DESCRIPTION
## TLDR
Introduced unit tests using GTest and integrated them into the CI/CD pipeline.

## Description
This PR addresses issue #3 by introducing a robust testing framework for the `pdf2cbz` project.

### Key Changes:
- **Core Library**: Extracted core logic from the main application into a `pdf2cbz_core` static library to facilitate unit testing.
- **Testing Framework**: Integrated Google Test (GTest) v1.14.0 via CMake `FetchContent`.
- **Unit Tests**:
    - `ConverterTest`: Tests the `calculateNumThreads` logic (now protected).
    - `ProgressBarTest`: Verifies standard output for progress updates.
- **CI/CD**: Added a "Run Tests" step to the `.github/workflows/release.yml` workflow, ensuring tests run on Linux and macOS for every release.
- **Documentation**: Updated `README.md` and `AGENTS.md` with testing instructions and technical references.

## Awareness
- The build system now relies on a static library for core components.
- Tests can be enabled using `-DENABLE_TESTS=ON` during CMake configuration.
- Fixed a long-standing issue with Poppler include paths by using `IMPORTED_TARGET`.

Resolves #3
